### PR TITLE
[Update] postcomment.css 프로필 이미지 형태 고정

### DIFF
--- a/css/postcomment.css
+++ b/css/postcomment.css
@@ -38,6 +38,7 @@ body {
 .usercomment-container .userprofile-img {
     width: 36px;
     height: 36px;
+    border-radius: 50%;
 }
 
 .usercomment-container .info-sec .userinfo-sec {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
postcomment.css 프로필 이미지 형태 고정

resolves: #86

- [ ] 신규 기능 추가 :
- [x] 기능 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유
이미지 상관없이 프로필 형태 동일하게 고정
### 작업 내역

- 작업 내역 
postcomment.css 프로필 이미지 크기 고정

### 작업 후 기대 동작(스크린샷)

- 동작 
![image](https://user-images.githubusercontent.com/73926393/178201702-d26faff3-547a-4803-b3ec-ccdeeb5c4f80.png)

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #86 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
