### PR TITLE
[Add] profile 페이지 html,css,js 상태별 프로필 정보

### DIFF
--- a/css/profile.css
+++ b/css/profile.css
@@ -108,10 +108,12 @@
   background: var(--enabled-color);
 }
 .chat-btn, .share-btn{
-  padding: 0;
+  padding: 6px;
   width: 34px;
+  height: 34px;
   line-height: 0.2;
   border: 1px solid var( --light-gray-color);
+  box-sizing: border-box;
 }
 
 /* my profile 프로필 수정, 상품 등록 */

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,5 +1,74 @@
 getUserProfile();
 
+/* 유저 정보 받아오기  */
+async function getUserProfile(accountname) {
+  const token = localStorage.getItem('token');
+  
+  // getAccount: 쿼리스트링에서 정보를 받아온다. 
+  const getAccount = location.search.replace("?","").split("=");
+  const accountName = (getAccount == '') ? 
+    localStorage.getItem('accountname') : getAccount[1];
+  
+  const getUserData = {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-type': 'application/json'
+    },
+  }
+  try{
+    // userProfile
+    const userProfileData = await fetch(`${url}/profile/${accountName}`, getUserData);
+    const userProfileJson = await userProfileData.json();
+    const userProfile = userProfileJson.profile;
+    setUserProfile(userProfile);
+    // 프로필 상태별 버튼
+    checkUser(userProfile);
+    
+    // userPost
+    const userPostData = await fetch(`${url}/post/${accountName}/userpost`, getUserData);
+    const userPostJson = await userPostData.json();
+    const userPost = userPostJson.post;
+    // setUserPost(userPost);
+
+  } catch(errorMsg) {
+    console.log(errorMsg);
+  }
+}
+
+/* 유저 프로필 정보 뿌려주기 */
+function setUserProfile(userProfile) {
+
+  const user_image = (userProfile.image) ? userProfile.image : '../assets/images/img-profile_large.png';
+  
+  document.querySelector('.follower-num').textContent = userProfile.followerCount;
+  document.querySelector('.following-num').textContent = userProfile.followingCount;
+  document.querySelector('.profile-img-wrap img').src = user_image;
+  document.querySelector('.profile-section .profile-name').textContent = userProfile.username;
+  document.querySelector('.profile-section .profile-account').textContent = `@ ${userProfile.accountname}`;
+  document.querySelector('.profile-section .profile-intro').textContent = userProfile.intro;
+}
+
+const myProfileBtnWrap = document.querySelector('.myProfile-btns');
+const followBtnWrap = document.querySelector('.follow-btns');
+const unfollowBtnWrap = document.querySelector('.unfollow-btns');
+/* 프로필 상태별 버튼 */
+function checkUser(userProfile) {
+  // userAccountname 현재 프로필 페이지에서 보이는 사용자
+  const localUser = localStorage.getItem('accountname');
+  const nowUser = userProfile.accountname;
+  
+  if (nowUser === localUser) { // 내 프로필일 때
+    myProfileBtnWrap.classList.add('on');
+  } else if (userProfile.isfollow == false) { // 팔로우 중이 아니라면
+    followBtnWrap.classList.add('on');
+  } else if (userProfile.isfollow == true ) { // 팔로우 중이라면
+    //unfollowBtnWrap.classList.add('on');
+    unfollowBtnWrap.style.display = 'flex';
+  }
+} 
+
+
 /* 게시글 - 리스트, 앨범 */
 function postViewtoggle(){
   const listWrap = document.querySelector(".post-list-wrap")
@@ -22,59 +91,3 @@ const albumBtn = document.querySelector("#post-album-btn");
 
 listBtn.addEventListener('click', postViewtoggle);
 albumBtn.addEventListener('click', postViewtoggle);
-
-
-/* 유저 정보 받아오기  */
-async function getUserProfile() {
-  const token = localStorage.getItem('token');
-  const accountName = localStorage.getItem('accountname');
-  const getUserData = {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${token}`,
-      'Content-type': 'application/json'
-    },
-  }
-
-  try{
-    // userProfile
-    const userProfileData = await fetch(`${url}/profile/${accountName}`, getUserData);
-    const userProfileJson = await userProfileData.json();
-    const userProfile = userProfileJson.profile;
-    console.log(userProfile);
-    setUserProfile(userProfile);
-
-    // userPost
-    const userPostData = await fetch(`${url}/post/${accountName}/userpost`, getUserData);
-    const userPostJson = await userPostData.json();
-    const userPost = userPostJson.post;
-    // setUserPost(userPost);
-
-    // 프로필 상태별 버튼
-    checkUser(userProfile);
-
-  } catch(errorMsg) {
-    console.log(errorMsg);
-  }
-}
-
-/* 유저 프로필 정보 뿌려주기 */
-function setUserProfile(userProfile) {
-  const user_image = (userProfile.image) ? userProfile.image : '../assets/images/img-profile_large.png';
-  
-  document.querySelector('.follower-num').textContent = userProfile.followerCount;
-  document.querySelector('.following-num').textContent = userProfile.followingCount;
-  document.querySelector('.profile-img-wrap img').src = user_image;
-  document.querySelector('.profile-section .profile-name').textContent = userProfile.username;
-  document.querySelector('.profile-section .profile-account').textContent = `@ ${userProfile.accountname}`;
-  document.querySelector('.profile-section .profile-intro').textContent = userProfile.intro;
-}
-
-/* 프로필 상태별 버튼 */
-function checkUser(userProfile) {
-  // localStorage에 있는 토큰이 다르다면
-    // 팔로우 목록에 있다면 
-      // follow-btn.textContent 를 팔로우
-    // 팔로우 목록에 없다면
-      // follow-btn.textContent 를 언팔로우 (클래스도 replace)
-} 

--- a/pages/profile.html
+++ b/pages/profile.html
@@ -43,7 +43,7 @@
         <p class="profile-intro">{profile-desc}</p>
         
         <!-- 마이 프로필 -->
-        <div class="myProfile-btns on">
+        <div class="myProfile-btns">
           <a class="myProfile-edit-btn" href="../pages/editprofile.html">프로필 수정</a>
           <a class="product-register-btn" href="../pages/product.html">상품 등록</a>
         </div>
@@ -66,7 +66,6 @@
           <button class="share-btn" type="button">
             <img src="../assets/images/icon/icon-share.svg" alt="공유하기">
           </button> 
-        </div>
       </div>
     </section>
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : profile 페이지 html,css,js 상태별 프로필 정보
- [ ] 기능 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유

- 프로필 페이지에서 다른 사용자의 프로필도 보이게 한다.

### 작업 내역

- html, css 수정으로 마이프로필, 팔로우한 유저 프로필, 언팔로우한 유저 프로필일 때 버튼 영역을 보여준다.


### 작업 후 기대 동작(스크린샷)

- 마이프로필
![image](https://user-images.githubusercontent.com/76831344/179677595-9f3907de-53aa-4270-a09b-3007d12eca24.png)

- 팔로우 중인 유저 프로필
![image](https://user-images.githubusercontent.com/76831344/179677527-950d0a6d-607f-485f-8071-b5ba9844b35e.png)


### PR 특이 사항

- 언팔로우 중인 유저 프로필은 팔로우 페이지 추가 후 확인할 수 있습니다. 

### Issue Number 

close: #179

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
