### PR TITLE
[Add] editprofile 기능 추가(기존 정보 입력값 유지 / 이미지 업로드 / 수정 데이터 갱신)

### DIFF
--- a/css/editprofile.css
+++ b/css/editprofile.css
@@ -1,6 +1,5 @@
 .editProfile-sec {
   margin-top: 102px;
-  /* display: none; */
 }
 
 .editProfile-title {

--- a/js/editprofile.js
+++ b/js/editprofile.js
@@ -70,3 +70,101 @@ const disabledBtn = () => {
   saveBtn.disabled = true;
   saveBtn.classList.remove('active');
 };
+
+//----------------------프로필 이미지 업로드---------------------------
+
+const profileImgBtn = document.querySelector('.editProfile-img-upload-btn');
+const hiddenImgSrc = document.querySelector('#editImgHidden');
+const editImg = document.querySelector('#editImg');
+
+// 버튼 클릭시 이미지 input 버튼 클릭
+profileImgBtn.addEventListener('click', () => {
+  editImg.click();
+});
+
+let readURL = function (input) {
+  if (input.files && input.files[0]) {
+    var reader = new FileReader();
+
+    reader.onload = function (e) {
+      document.querySelector(
+        '.editprofile-edit-wrap'
+      ).style.background = `url(${e.target.result}) center center / cover`;
+      hiddenImgSrc.value = e.target.result;
+    };
+    reader.readAsDataURL(input.files[0]);
+  }
+};
+editImg.addEventListener('change', function (e) {
+  readURL(this);
+});
+
+//----------------------프로필 수정 데이터 갱신---------------------------
+
+async function editUserInfo() {
+  const url = 'https://mandarin.api.weniv.co.kr';
+  const token = localStorage.getItem('token');
+  try {
+    const res = await fetch(`${url}/user`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user: {
+          username: editUsernameInput.value,
+          accountname: editAccountInput.value,
+          intro: editIntroInput.value,
+          image: hiddenImgSrc.value,
+        },
+      }),
+    });
+    const resJson = await res.json();
+    console.log(resJson);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+saveBtn.addEventListener('click', () => {
+  editUserInfo();
+  localStorage.setItem('accountname', editAccountInput.value);
+  location.href = './profile.html';
+});
+
+//----------------------기존 정보 프로필 수정 input에 유지---------------------------
+
+function setEditUserInfo(editUserInfo) {
+  document.querySelector(
+    '.editprofile-edit-wrap'
+  ).style.background = `url(${editUserInfo.image}) no-repeat center / 110px`;
+
+  hiddenImgSrc.value = editUserInfo.image;
+  editUsernameInput.value = editUserInfo.username;
+  editAccountInput.value = editUserInfo.accountname;
+  editIntroInput.value = editUserInfo.intro;
+}
+
+//----------------------프로필 수정 데이터 전송---------------------------
+
+async function getEditUserInfo() {
+  const url = 'https://mandarin.api.weniv.co.kr';
+  const accountName = localStorage.getItem('accountname');
+  const token = localStorage.getItem('token');
+  try {
+    const res = await fetch(`${url}/profile/${accountName}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+    });
+    const resJson = await res.json();
+    setEditUserInfo(resJson.profile);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+getEditUserInfo();


### PR DESCRIPTION
editprofile 기능 추가(기존 정보 입력값 유지 / 이미지 업로드 / 수정 데이터 갱신)

resolves: #208

### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : 기존 정보 입력값 유지 / 이미지 업로드 / 수정 데이터 갱신 기능 추가
- [ ] 기능 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유
기존 정보 입력값 유지 / 이미지 업로드 / 수정 데이터 갱신 기능 추가

- 이유

### 작업 내역

- 작업 내역 
기존 정보 입력값 유지 / 이미지 업로드 / 수정 데이터 갱신 기능 추가

### 작업 후 기대 동작(스크린샷)
![스크린샷 2022-07-21 오후 1 33 31](https://user-images.githubusercontent.com/96808980/180138616-592dc5a1-4461-48c5-a8f9-3f7f3df91220.png)
위의 문제 발생하여 완성 후 다시 PR할때 올리겠습니다!

- 동작 
프로필 수정 페이지로 들어갈 시 input 입력값을 기존 데이터로 유지
이미지 업로드 가능
수정 데이터 API로 갱신

### PR 특이 사항

- 특이 사항
내 정보 페이지로 데이터가 적용되지 않는 문제 발생 - 

### Issue Number 

close: #208 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
