### PR TITLE
[Fix] 프로필 수정 후 내 정보 페이지에 데이터를 읽지 못하는 이슈 해결 및 스타일 수정

### DIFF
--- a/css/editprofile.css
+++ b/css/editprofile.css
@@ -3,7 +3,6 @@
 }
 
 .editProfile-title {
-  padding-top: 55px;
   margin-bottom: 12px;
   font-size: 24px;
   font-weight: 500;

--- a/js/editprofile.js
+++ b/js/editprofile.js
@@ -122,6 +122,8 @@ async function editUserInfo() {
     });
     const resJson = await res.json();
     console.log(resJson);
+    localStorage.setItem('accountname', editAccountInput.value);
+    location.href = './profile.html';
   } catch (err) {
     console.error(err);
   }
@@ -129,8 +131,6 @@ async function editUserInfo() {
 
 saveBtn.addEventListener('click', () => {
   editUserInfo();
-  localStorage.setItem('accountname', editAccountInput.value);
-  location.href = './profile.html';
 });
 
 //----------------------기존 정보 프로필 수정 input에 유지---------------------------


### PR DESCRIPTION
프로필 수정 후 내 정보 페이지에 데이터를 읽지 못하는 이슈 해결

resolves: #214

### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 기능 수정 : 타이틀 상단 Padding 수정
- [x] 버그 수정 : 프로필 수정 후 내 정보 페이지에서 데이터를 읽지 못하는 이슈 해결
- [ ] 기타 : 

### 변경사항 및 이유
프로필 수정 후 데이터의 처리되는 순서 변경

- 이유
프로필 수정 후 비동적인 처리 순서로 인한 에러 발생

### 작업 내역

- 작업 내역 

### 작업 후 기대 동작(스크린샷)
- 에러 해결
![화면 기록 2022-07-22 오전 8 14 55](https://user-images.githubusercontent.com/96808980/180331401-9c951ebd-37dc-4205-b886-1223ad7f8fd9.gif)
- 스타일 수정 (타이틀 상단 padding 수정)
![image](https://user-images.githubusercontent.com/96808980/180349889-3a7e0f5f-308c-4e19-b7eb-369a55f9c577.png)


- 동작 
프로필 수정 후 내 정보에서 데이터를 정상적으로 받아온다.

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #214 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
정상적으로 데이터를 받아올 수 있는지 확인

<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
