### PR TITLE
[Fix] 프로필 수정 페이지 버그 수정(새로운 계정ID 입력 후 기존 계정ID를 다시 입력 시 에러 메세지 발생)

### DIFF
--- a/js/editprofile.js
+++ b/js/editprofile.js
@@ -8,6 +8,7 @@ const saveBtn = document.querySelector('.save');
 // 계정 검증 API
 async function accountnameValid() {
   const url = 'https://mandarin.api.weniv.co.kr';
+  const currentId = localStorage.getItem('accountname');
   try {
     const res = await fetch(`${url}/user/accountnamevalid`, {
       method: 'POST',
@@ -21,16 +22,21 @@ async function accountnameValid() {
       }),
     });
     const resJson = await res.json();
-    console.log(resJson);
     if (resJson.message === '이미 가입된 계정ID 입니다.') {
       editAccountInput.classList.add('error');
       errEditProfile.textContent = `*이미 가입된 계정ID 입니다.`;
       errEditProfile.style.display = 'block';
+      if (currentId === editAccountInput.value) {
+        editAccountInput.classList.remove('error');
+        errEditProfile.textContent = null;
+        errEditProfile.style.display = 'none';
+      }
     }
   } catch (err) {
     console.error(err);
   }
 }
+
 // 계정 형식이 맞는지 확인
 const checkAccForm = () => {
   const regExp = /^[0-9a-zA-Z._]*$/i;
@@ -45,9 +51,9 @@ const checkAccForm = () => {
 };
 
 // 계정ID에 입력 시 계정 검증과 계정 형식이 올바른지 확인 실행
-editAccountInput.addEventListener('input', async () => {
+editAccountInput.addEventListener('input', (e) => {
   checkAccForm();
-  await accountnameValid();
+  accountnameValid();
   // 에러 메세지가 있거나 계정ID 값이 없을 때 버튼 활성/비활성
   if (
     errEditProfile.style.display === 'block' ||
@@ -122,6 +128,7 @@ async function editUserInfo() {
     });
     const resJson = await res.json();
     console.log(resJson);
+
     localStorage.setItem('accountname', editAccountInput.value);
     location.href = './profile.html';
   } catch (err) {
@@ -162,6 +169,7 @@ async function getEditUserInfo() {
     });
     const resJson = await res.json();
     setEditUserInfo(resJson.profile);
+    return resJson.profile;
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
프로필 수정 페이지 버그 수정(새로운 계정ID 입력 후 기존 계정ID를 다시 입력 시 에러 메세지 발생)

resolves: #237

### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 기능 수정 : 새로운 계정ID 입력 후 기존 계정ID를 다시 입력 시 에러 메세지 발생 이슈 수정
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

- 작업 내역 

### 작업 후 기대 동작(스크린샷)
![같은계정일때](https://user-images.githubusercontent.com/96808980/180442289-ab3a3412-3519-43e8-bbcd-d2ca30d293e7.gif)

- 동작 
이전과 동일한 계정일 때 에러 메세지 출력하지 않음

### PR 특이 사항

- 특이 사항
API 통신 성공으로 인해 중복 계정이라는 메세지는 뜹니다. 만약 더 좋은 코드가 생각나면 다시 업데이트하겠습니다.

### Issue Number 

close: #237

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
동일한 계정 입력 시 에러 메세지 출력하는지 확인

<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
