### PR TITLE
[Fix] 팔로우, 팔로잉 리스트 로그인 유저 버튼 지우기, js파일 통합

### DIFF
--- a/js/follow.js
+++ b/js/follow.js
@@ -1,0 +1,192 @@
+/* 팔로우한 상태 구분 */
+const userListWrap = document.querySelector('.user-list-wrap');
+
+getFollowList();
+
+/* 팔로잉 리스트 받아오기  */
+async function getFollowList() {
+  const token = localStorage.getItem('token');
+
+  const getAccount = location.search.replace("?", "").split("=");
+  const accountName = (getAccount == '') ?
+    localStorage.getItem('accountname') : getAccount[1];
+
+  const getFollowingData = {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-type': 'application/json'
+    },
+  }
+  // 현재 로그인한 사용자
+  const userProfileData = await fetch(`${url}/profile/${accountName}`, getFollowingData);
+  const userProfileJson = await userProfileData.json();
+  const userProfile = userProfileJson.profile;
+
+  // following
+  const followingData = await fetch(`${url}/profile/${accountName}/following`, getFollowingData);
+  const followingList = await followingData.json();
+
+  const followerData = await fetch(`${url}/profile/${accountName}/follower`, getFollowingData);
+  const followerList = await followerData.json();
+  
+  if ( document.querySelector('.page-title') === 'Followings') {
+    setFollowingList(followingList);
+  } else {
+    setFollowerList(followerList);
+  }
+}
+
+// following
+function setFollowingList(followingList) {
+  if (followingList.length === 0) {
+    const noFollowMsg = document.createElement('li');
+    noFollowMsg.setAttribute('class', 'noFollow-msg-wrap');
+
+    const msgStrong = document.createElement('strong');
+    msgStrong.setAttribute('class', 'msg-strong');
+    msgStrong.innerText = '팔로우한 계정이 없습니다.';
+
+    const msgP = document.createElement('p');
+    msgP.setAttribute('class', 'msg-p');
+    msgP.innerText = '유저를 검색해 팔로우 해보세요!';
+
+    // li > strong+p
+    noFollowMsg.appendChild(msgStrong);
+    noFollowMsg.appendChild(msgP);
+    // ul > li
+    userListWrap.appendChild(noFollowMsg);
+
+  } else {
+    followingList.forEach((i) => {
+
+      const userProfileWrap = document.createElement('li');
+      userProfileWrap.setAttribute('class', 'user-profile-li');
+
+      const userProfileLink = document.createElement('a');
+      userProfileLink.setAttribute('href', `/pages/profile.html?accountname=${i.accountname}`);
+
+      const userProfileImg = document.createElement('img');
+      userProfileImg.setAttribute('class', 'user-img');
+      userProfileImg.setAttribute('src', i.image);
+
+      /* user-info */
+      const userInfoWrap = document.createElement('div');
+      userInfoWrap.setAttribute('class', 'user-info');
+
+      const userInfoName = document.createElement('strong');
+      userInfoName.setAttribute('class', 'user-name');
+      userInfoName.innerText = i.username;
+
+      const userInfoIntro = document.createElement('span');
+      userInfoIntro.setAttribute('class', 'user-intro');
+      userInfoIntro.innerText = i.intro;
+
+      /* 팔로우한 상태 구분 */
+      const userFollowBtn = document.createElement('button');
+
+      if (i.isfollow) {
+        userFollowBtn.setAttribute('class', 'user-follow-btn cancel');
+        userFollowBtn.setAttribute('id', 'user-follow-btn-cancel');
+        userFollowBtn.innerText = '취소';
+      } else {
+        if (i.accountname === localStorage.getItem('accountname')) {
+          userFollowBtn.style.display = 'none';
+        } else {
+          userFollowBtn.setAttribute('class', 'user-follow-btn');
+          userFollowBtn.setAttribute('id', 'user-follow-btn');
+          userFollowBtn.innerText = '팔로우';
+        }
+      }
+      // a > img
+      userProfileLink.appendChild(userProfileImg);
+      // a > div < name+intro
+      userInfoWrap.appendChild(userInfoName);
+      userInfoWrap.appendChild(userInfoIntro);
+      userProfileLink.appendChild(userInfoWrap);
+      // li > a , li > button
+      userProfileWrap.appendChild(userProfileLink);
+      userProfileWrap.appendChild(userFollowBtn);
+      // ul > li
+      userListWrap.appendChild(userProfileWrap);
+    });
+  }
+  followData(followingList);
+}
+
+// follower
+function setFollowerList(followerList) {
+  if (followerList.length === 0) {
+    const noFollowMsg = document.createElement('li');
+    noFollowMsg.setAttribute('class', 'noFollow-msg-wrap');
+    
+    const msgStrong = document.createElement('strong');
+    msgStrong.setAttribute('class', 'msg-strong');
+    msgStrong.innerText = '팔로워 계정이 없습니다.';
+    
+    const msgP = document.createElement('p');
+    msgP.setAttribute('class', 'msg-p');
+    msgP.innerText = '유저를 검색해 팔로우 해보세요!';
+
+    // li > strong+p
+    noFollowMsg.appendChild(msgStrong);
+    noFollowMsg.appendChild(msgP);
+    // ul > li
+    userListWrap.appendChild(noFollowMsg);
+
+  } else {
+    followerList.forEach((i) => {
+
+      const userProfileWrap = document.createElement('li');
+      userProfileWrap.setAttribute('class', 'user-profile-li');
+      
+      const userProfileLink = document.createElement('a');
+      userProfileLink.setAttribute('href', `/pages/profile.html?accountname=${i.accountname}`);
+
+      const userProfileImg = document.createElement('img');
+      userProfileImg.setAttribute('class', 'user-img');
+      userProfileImg.setAttribute('src', i.image);
+
+      /* user-info */
+      const userInfoWrap = document.createElement('div');
+      userInfoWrap.setAttribute('class', 'user-info');
+
+      const userInfoName = document.createElement('strong');
+      userInfoName.setAttribute('class', 'user-name');
+      userInfoName.innerText = i.username;
+
+      const userInfoIntro = document.createElement('span');
+      userInfoIntro.setAttribute('class', 'user-intro');
+      userInfoIntro.innerText = i.intro;
+
+      /* 팔로우한 상태 구분 버튼 */
+      const userFollowBtn = document.createElement('button');
+
+      if (i.isfollow) { 
+        userFollowBtn.setAttribute('class', 'user-follow-btn cancel');
+        userFollowBtn.setAttribute('id', 'user-follow-btn-cancel');
+        userFollowBtn.innerText = '취소';
+      } else {
+        if (i.accountname === localStorage.getItem('accountname')) {
+          userFollowBtn.style.display = 'none'
+        } else {
+          userFollowBtn.setAttribute('class', 'user-follow-btn');
+          userFollowBtn.setAttribute('id', 'user-follow-btn');
+          userFollowBtn.innerText = '팔로우';
+        }
+      }
+      // a > img
+      userProfileLink.appendChild(userProfileImg);
+      // a > div < name+intro
+      userInfoWrap.appendChild(userInfoName);
+      userInfoWrap.appendChild(userInfoIntro);
+      userProfileLink.appendChild(userInfoWrap);
+      // li > a , li > button
+      userProfileWrap.appendChild(userProfileLink);
+      userProfileWrap.appendChild(userFollowBtn);
+      // ul > li
+      userListWrap.appendChild(userProfileWrap);
+    });
+  }
+  followData(followerList)
+}

--- a/js/followers.js
+++ b/js/followers.js
@@ -31,11 +31,11 @@ async function getFollowerList() {
   const userAccountname =userProfile.accountname;
   const userFollowing = userProfile.follower; // 로컬유저가 팔로잉중인사람
 
-  setFollowerList(followerList, userId, userFollowing);
+  setFollowerList(followerList, userId, userAccountname, userFollowing);
 
 }
 
-function setFollowerList(followerList, userId, userFollowing) {
+function setFollowerList(followerList, userId, userAccountname, userFollowing) {
   if (followerList.length === 0) {
     const noFollowMsg = document.createElement('li');
     noFollowMsg.setAttribute('class', 'noFollow-msg-wrap');
@@ -79,25 +79,22 @@ function setFollowerList(followerList, userId, userFollowing) {
       userInfoIntro.setAttribute('class', 'user-intro');
       userInfoIntro.innerText = i.intro;
 
-      /* 팔로우한 상태 구분 */
+      /* 팔로우한 상태 구분 버튼 */
       const userFollowBtn = document.createElement('button');
-      userFollowBtn.setAttribute('class', 'user-follow-btn');
-      userFollowBtn.setAttribute('id', 'user-follow-btn');
 
-      //userFollowBtn.addEventListener('click', changeFollowList(i._id));
-
- //     if ((i.follower).includes(userId)) {
-      if (i.isfollow) {
+      if (i.isfollow) { 
         userFollowBtn.setAttribute('class', 'user-follow-btn cancel');
         userFollowBtn.setAttribute('id', 'user-follow-btn-cancel');
         userFollowBtn.innerText = '취소';
-
       } else {
-        userFollowBtn.setAttribute('class', 'user-follow-btn');
-        userFollowBtn.setAttribute('id', 'user-follow-btn');
-        userFollowBtn.innerText = '팔로우';
+        if (i.accountname === localStorage.getItem('accountname')) {
+          userFollowBtn.style.display = 'none'
+        } else {
+          userFollowBtn.setAttribute('class', 'user-follow-btn');
+          userFollowBtn.setAttribute('id', 'user-follow-btn');
+          userFollowBtn.innerText = '팔로우';
+        }
       }
-
       // a > img
       userProfileLink.appendChild(userProfileImg);
       // a > div < name+intro
@@ -110,8 +107,6 @@ function setFollowerList(followerList, userId, userFollowing) {
       // ul > li
       userListWrap.appendChild(userProfileWrap);
     });
-    
-    
   }
   followData(followerList)
 }

--- a/js/followings.js
+++ b/js/followings.js
@@ -82,22 +82,20 @@ function setFollowingList(followingList, userId, userFollowing) {
 
       /* 팔로우한 상태 구분 */
       const userFollowBtn = document.createElement('button');
-      userFollowBtn.setAttribute('class', 'user-follow-btn');
-      userFollowBtn.setAttribute('id', 'user-follow-btn');
-
-      //userFollowBtn.addEventListener('click', changeFollowList(i._id));
 
       if (i.isfollow) {
         userFollowBtn.setAttribute('class', 'user-follow-btn cancel');
         userFollowBtn.setAttribute('id', 'user-follow-btn-cancel');
         userFollowBtn.innerText = '취소';
-
       } else {
-        userFollowBtn.setAttribute('class', 'user-follow-btn');
-        userFollowBtn.setAttribute('id', 'user-follow-btn');
-        userFollowBtn.innerText = '팔로우';
+        if (i.accountname === localStorage.getItem('accountname')) {
+          userFollowBtn.style.display = 'none';
+        } else {
+          userFollowBtn.setAttribute('class', 'user-follow-btn');
+          userFollowBtn.setAttribute('id', 'user-follow-btn');
+          userFollowBtn.innerText = '팔로우';
+        }
       }
-
       // a > img
       userProfileLink.appendChild(userProfileImg);
       // a > div < name+intro

--- a/pages/followers.html
+++ b/pages/followers.html
@@ -20,22 +20,10 @@
   </header>
   <main class="main">
       <ul class="user-list-wrap">
-        <!-- <li class="user-profile-li">
-          <a href="">
-            <img src="../assets/images/feed_room_03.jpg" alt="프로필 사진" class="user-img">
-          </a>
-          <div class="user-info">
-            <a href="">
-              <strong class="user-name">애월읍 츄르 맛집</strong>
-              <span class="user-info">자기소개</span>
-            </a>
-          </div>
-          <button class="user-follow-btn" type="button">팔로우</button>
-        </li> -->
-        
       </ul>
   </main>
   <script src="../js/common.js"></script>
-  <script src="../js/followers.js"></script>
+  <!-- <script src="../js/followers.js"></script> -->
+  <script src="../js/follow.js"></script>
 </body>
 </html>

--- a/pages/followings.html
+++ b/pages/followings.html
@@ -23,6 +23,7 @@
       </ul>
   </main>
   <script src="../js/common.js"></script>
-  <script src="../js/followings.js"></script>
+  <!-- <script src="../js/followings.js"></script> -->
+  <script src="../js/follow.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 기능 수정 :
- [x] 버그 수정 : 팔로우, 팔로잉 리스트 로그인 유저 버튼 지우기, followings.js, followers.js 하나의 follow.js로 합치기
- [ ] 기타 : 

### 변경사항 및 이유

- 다른 사용자의 팔로우, 팔로잉 리스트에서 로그인한 사용자 계정에도 팔로우 버튼이 보였다.
- followings.js, followers.js 두 개의 파일에서 중복되는 코드를 하나로 합쳤다. 

### 작업 내역

- accountname이 로컬스토리지의 accountname과 동일하다면 버튼을 보여주지 않는다.
- followings.js, followers.js 두 개의 파일에서 중복되는 코드를 하나로 합쳤다. 
- 
### 작업 후 기대 동작(스크린샷)

![image](https://user-images.githubusercontent.com/76831344/180597332-01465031-0311-4400-937b-728a107ae813.png)
![image](https://user-images.githubusercontent.com/76831344/180597340-9a4142a6-85ce-4b8f-a916-ae49da6ef820.png)

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #235

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
