### PR TITLE
[Fix] 팔로워, 팔로잉 페이지 팔로워만 보이는 현상 해결

### DIFF
--- a/js/follow.js
+++ b/js/follow.js
@@ -1,5 +1,6 @@
 /* 팔로우한 상태 구분 */
 const userListWrap = document.querySelector('.user-list-wrap');
+const pageTitle = document.querySelector('.page-title').textContent;
 
 getFollowList();
 
@@ -30,9 +31,9 @@ async function getFollowList() {
   const followerData = await fetch(`${url}/profile/${accountName}/follower`, getFollowingData);
   const followerList = await followerData.json();
   
-  if ( document.querySelector('.page-title') === 'Followings') {
+  if ( pageTitle === 'Followings') {
     setFollowingList(followingList);
-  } else {
+  } else if( pageTitle === 'Followers') {
     setFollowerList(followerList);
   }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 기능 수정 :
- [x] 버그 수정 : 팔로워, 팔로잉 페이지 팔로워만 보이는 현상 해결
- [ ] 기타 : 

### 변경사항 및 이유

- 팔로워, 팔로잉 페이지 팔로워만 보인다.

### 작업 내역

- 팔로워, 팔로잉 페이지 구별하는 조건문 수정해서
팔로워, 팔로잉 페이지에서 각각의 데이터가 보여지게 한다.


### 작업 후 기대 동작(스크린샷)

![chrome-capture-2022-6-25](https://user-images.githubusercontent.com/76831344/180682550-03f9b790-5a91-4b5a-b9a1-1c42558081fa.gif)


### PR 특이 사항

- 특이 사항

### Issue Number 

close: #246

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
