### PR TITLE
[Add] splash 페이지 로드 후 localstorage에 token이 존재 시 feed 페이지로 이동하는 기능 구현

### DIFF
--- a/js/splash.js
+++ b/js/splash.js
@@ -1,5 +1,8 @@
 // 1초 후 지정한 경로로 페이지 이동
-
 window.setTimeout(() => {
-  location.href = '/pages/intro.html';
+  if (localStorage.getItem('token')) {
+    location.href = '/pages/feed.html';
+  } else {
+    location.href = '/pages/intro.html';
+  }
 }, 1000);


### PR DESCRIPTION
splash 페이지에서 이미 token을 가지고 있는 로그인 상태라면 feed 페이지로 이동

resolves: #254

### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : splash 페이지 로드 시 localstorage에서 token의 값을 가지고 있는지 확인하여 있으면 바로 feed 페이지로 이동하고 없을 시 intro 페이지로 이동하는 기능 구현 
- [ ] 기능 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유
splash 페이지 로드 시 localstorage에서 token의 값을 가지고 있는지 확인하여 있으면 바로 feed 페이지로 이동하고 없을 시 intro 페이지로 이동하는 기능 구현 

- 이유

### 작업 내역

- 작업 내역 

### 작업 후 기대 동작(스크린샷)
토큰없을 때
![토근없음](https://user-images.githubusercontent.com/96808980/180781835-775b5130-76fe-436a-8378-bfd316abc7fc.gif)
토큰있을 때
![토큰있음](https://user-images.githubusercontent.com/96808980/180781894-16d5c52f-5344-490f-ba1c-b8231feb2765.gif)

- 동작 
토큰이 있을 때 feed 페이지로 바로 이동
없을 경우 intro 페이지에서 로그인/회원가입 가능 

### PR 특이 사항

- 특이 사항
로컬스토리지 토큰 확인

### Issue Number 

close: #254 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
이동이 안될 시 로컬스토리지 확인

<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
