### PR TITLE
[Update] 프로필 수정 페이지 이미지 용량 초과 시 경고 메세지 출력(페이지 이동x)

### DIFF
--- a/js/editprofile.js
+++ b/js/editprofile.js
@@ -5,6 +5,47 @@ const editIntroInput = document.querySelector('#editIntroduce-input');
 const errEditProfile = document.querySelector('.editprofile-error-msg');
 const saveBtn = document.querySelector('.save');
 
+// 버튼 활성화
+const activateBtn = () => {
+  saveBtn.disabled = false;
+  saveBtn.classList.add('active');
+};
+
+// 버튼 비활성화
+const disabledBtn = () => {
+  saveBtn.disabled = true;
+  saveBtn.classList.remove('active');
+};
+
+// 프로필 이미지 업로드
+const profileImgBtn = document.querySelector('.editProfile-img-upload-btn');
+const hiddenImgSrc = document.querySelector('#editImgHidden');
+const editImg = document.querySelector('#editImg');
+
+// 버튼 클릭시 이미지 input 버튼 클릭
+profileImgBtn.addEventListener('click', () => {
+  editImg.click();
+});
+
+let readURL = function (input) {
+  if (input.files && input.files[0]) {
+    let reader = new FileReader();
+
+    reader.onload = function (e) {
+      document.querySelector(
+        '.editprofile-edit-wrap'
+      ).style.background = `url(${e.target.result}) center center / cover`;
+      hiddenImgSrc.value = e.target.result;
+    };
+    reader.readAsDataURL(input.files[0]);
+  }
+};
+
+// 이미지 변경 시 미리보기와
+editImg.addEventListener('change', function () {
+  readURL(this);
+});
+
 // 계정 검증 API
 async function accountnameValid() {
   const url = 'https://mandarin.api.weniv.co.kr';
@@ -65,48 +106,7 @@ editAccountInput.addEventListener('input', (e) => {
   }
 });
 
-// 버튼 활성화
-const activateBtn = () => {
-  saveBtn.disabled = false;
-  saveBtn.classList.add('active');
-};
-
-// 버튼 비활성화
-const disabledBtn = () => {
-  saveBtn.disabled = true;
-  saveBtn.classList.remove('active');
-};
-
-//----------------------프로필 이미지 업로드---------------------------
-
-const profileImgBtn = document.querySelector('.editProfile-img-upload-btn');
-const hiddenImgSrc = document.querySelector('#editImgHidden');
-const editImg = document.querySelector('#editImg');
-
-// 버튼 클릭시 이미지 input 버튼 클릭
-profileImgBtn.addEventListener('click', () => {
-  editImg.click();
-});
-
-let readURL = function (input) {
-  if (input.files && input.files[0]) {
-    var reader = new FileReader();
-
-    reader.onload = function (e) {
-      document.querySelector(
-        '.editprofile-edit-wrap'
-      ).style.background = `url(${e.target.result}) center center / cover`;
-      hiddenImgSrc.value = e.target.result;
-    };
-    reader.readAsDataURL(input.files[0]);
-  }
-};
-editImg.addEventListener('change', function (e) {
-  readURL(this);
-});
-
-//----------------------프로필 수정 데이터 갱신---------------------------
-
+// 프로필 수정 데이터 갱신
 async function editUserInfo() {
   const url = 'https://mandarin.api.weniv.co.kr';
   const token = localStorage.getItem('token');
@@ -127,10 +127,12 @@ async function editUserInfo() {
       }),
     });
     const resJson = await res.json();
-    console.log(resJson);
-
-    localStorage.setItem('accountname', editAccountInput.value);
-    location.href = './profile.html';
+    if (resJson.message === 'request entity too large') {
+      alert('이미지의 용량이 너무 큽니다. 이미지를 변경해주세요.');
+    } else {
+      localStorage.setItem('accountname', editAccountInput.value);
+      location.href = './profile.html';
+    }
   } catch (err) {
     console.error(err);
   }
@@ -140,8 +142,7 @@ saveBtn.addEventListener('click', () => {
   editUserInfo();
 });
 
-//----------------------기존 정보 프로필 수정 input에 유지---------------------------
-
+// 기존 정보 프로필 수정 input에 유지
 function setEditUserInfo(editUserInfo) {
   document.querySelector(
     '.editprofile-edit-wrap'
@@ -153,8 +154,7 @@ function setEditUserInfo(editUserInfo) {
   editIntroInput.value = editUserInfo.intro;
 }
 
-//----------------------프로필 수정 데이터 전송---------------------------
-
+// 프로필 수정 데이터 전송
 async function getEditUserInfo() {
   const url = 'https://mandarin.api.weniv.co.kr';
   const accountName = localStorage.getItem('accountname');
@@ -169,7 +169,6 @@ async function getEditUserInfo() {
     });
     const resJson = await res.json();
     setEditUserInfo(resJson.profile);
-    return resJson.profile;
   } catch (err) {
     console.error(err);
   }

--- a/pages/editprofile.html
+++ b/pages/editprofile.html
@@ -14,7 +14,7 @@
       <button class="back-btn">
         <img src="../assets/images/icon/icon-arrow-left.svg" alt="뒤로가기" />
       </button>
-      <button class="nav-btn save submit-btn" disabled>저장</button>
+      <button class="nav-btn save submit-btn active">저장</button>
     </header>
 
     <section class="editProfile-sec">
@@ -65,7 +65,8 @@
             type="text"
             class="editprofile-input editIntroduce-input"
             id="editIntroduce-input"
-            placeholder="소개글을 작성해주세요!"
+            placeholder="소개글을 작성해주세요!(최대 50자)"
+            maxlength="50"
           />
         </div>
       </form>


### PR DESCRIPTION
프로필 수정 페이지 이미지 용량 초과 시 경고 메세지 출력(페이지 이동x)

resolves: #258

### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 기능 수정 : 이미지 용량 초과 시 경고 메세지를 출력
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유
이미지 용량 초과 시 경고 메세지 출력
및 기능 순으로 정렬 

- 이유
프로필 페이지의 에러를 방지

### 작업 내역

- 작업 내역 

### 작업 후 기대 동작(스크린샷)
<img width="802" alt="image" src="https://user-images.githubusercontent.com/96808980/180787492-3935d55d-95e5-4a65-92d5-67a7867be1a8.png">

- 동작 

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #258 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
에러 메세지가 출력 / 페이지 이동 여부

<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
