### PR TITLE
[Fix] profile 페이지 아이디,자기소개 글자 수 넘침, 팔로우버튼 깨짐

### DIFF
--- a/css/feed.css
+++ b/css/feed.css
@@ -89,6 +89,7 @@
   font-size: 10px;
   font-weight: 400;
   color: var(--gray-text-color);
+  word-break: break-word; 
 }
 
 .post-nav .post-menu-button {

--- a/css/profile.css
+++ b/css/profile.css
@@ -76,6 +76,7 @@
   font-size: 12px;
   line-height: 14px;
   margin-bottom: 17px;
+  word-break: break-word; 
 }
 .profile-wrap .profile-intro {
   color: var(--gray-text-color);
@@ -83,6 +84,7 @@
   font-size: 14px;
   line-height: 17px;
   margin-bottom: 24px;
+  word-break: break-word; 
 }
 
 /* 팔로우, 언팔로우, 프로필 수정, 상품 등록 버튼 */

--- a/js/profile.js
+++ b/js/profile.js
@@ -113,15 +113,13 @@ function setUserProfile(userProfile, followList) {
 
   const localUser = localStorage.getItem('accountname');
   const nowUser = userProfile.accountname;
-  console.log(userProfile.isfollow);
 
   if (nowUser === localUser) { // 내 프로필일 때
-    myProfileBtnWrap.classList.add('on');
-  }
-  else if (userProfile.isfollow === false) { // 팔로우 중이 아니라면
+    myProfileBtnWrap.style.display = 'flex';
+  } else if (userProfile.isfollow === false) {
     followBtnWrap.style.display = 'flex';
     followBtn.textContent = '팔로우';
-  } else if (userProfile.isfollow === true) { // 팔로우 중이라면
+  } else if (userProfile.isfollow === true) { 
     followBtnWrap.style.display = 'flex';
     followBtn.classList.replace('user-follow-btn', 'user-unfollow-btn');
     followBtn.textContent = '언팔로우';


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 기능 수정 :
- [x] 버그 수정 : flex가 깨지는 부분 수정
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

- 아이디, 자기소개 부분에 word-break: break-word; 추가하여 영역을 벗어나면
다음줄로 넘어가게한다.
팔로우 버튼을 .on(display: block;)으로 컨트롤 중이라서 flex가 깨지는
부분을 display:flex 와 display none으로 수정

- 게시글에서도 동일하게 아이디 넘치는 현상때문에 css 속성 추가
 

### 작업 후 기대 동작(스크린샷)

- 
![image](https://user-images.githubusercontent.com/76831344/180792210-342d3c97-44e5-4dc7-91d3-2ac54574b0a3.png)
![image](https://user-images.githubusercontent.com/76831344/180792258-1e2919e4-aa2f-4264-b4e4-59c84a49e36a.png)


### PR 특이 사항

- 특이 사항

### Issue Number 

close: #249 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
