### PR TITLE
[Fix] follow 이미지 엑박 처리, css 수정

### DIFF
--- a/css/userList.css
+++ b/css/userList.css
@@ -14,11 +14,12 @@
   display: flex;
   align-items: center;
   width: 100%;
+  justify-content: space-between;
 }
 .user-img {
   margin-right: 12px;
   width: 100%;
-  max-width: 50px;
+  min-width: 50px;
   height: 50px;
   object-fit: cover;
   border-radius: 50%;
@@ -27,7 +28,6 @@
 
 /* 유저 정보 */
 .user-info {
-  flex-grow: 2;
   margin-right: 12px;
 }
 .user-info .user-name {
@@ -47,7 +47,7 @@
   font-size: 12px;
   line-height: 14px;
   color: var(--gray-text-color);
-  width: 225px;
+  width: 210px;
   display: inline-block;
 }
 
@@ -59,7 +59,7 @@
 
 /* 팔로우 */
 .user-profile-li a {
-  display: contents;
+  display: flex;
   width: 50px;
   height: 50px;
   margin-right: 12px;

--- a/js/follow.js
+++ b/js/follow.js
@@ -2,6 +2,7 @@
 const userListWrap = document.querySelector('.user-list-wrap');
 const pageTitle = document.querySelector('.page-title').textContent;
 
+
 getFollowList();
 
 /* 팔로잉 리스트 받아오기  */
@@ -68,7 +69,7 @@ function setFollowingList(followingList) {
 
       const userProfileImg = document.createElement('img');
       userProfileImg.setAttribute('class', 'user-img');
-      userProfileImg.setAttribute('src', i.image);
+      userProfileImg.setAttribute('src', imgCheck(i.image));
 
       /* user-info */
       const userInfoWrap = document.createElement('div');
@@ -145,7 +146,7 @@ function setFollowerList(followerList) {
 
       const userProfileImg = document.createElement('img');
       userProfileImg.setAttribute('class', 'user-img');
-      userProfileImg.setAttribute('src', i.image);
+      userProfileImg.setAttribute('src', imgCheck(i.image));
 
       /* user-info */
       const userInfoWrap = document.createElement('div');
@@ -189,4 +190,19 @@ function setFollowerList(followerList) {
     });
   }
   followData(followerList)
+}
+
+const marketImg = "http://146.56.183.55:5050/Ellipse.png"; // 감귤마켓 기본이미지 
+const mandarinImg = "https://mandarin.api.weniv.co.kr/Ellipse.png"; // 감귤마켓 기본이미지 
+const defaultImg = "../assets/images/img-profile_large.png"; 
+
+// 이미지 예외처리
+function imgCheck(img) {
+  if (img === marketImg || img == mandarinImg || img == defaultImg) {
+    return defaultImg;
+  } else if (img.search(url) !== -1 || img.search('base64') !== -1 || img.search('.svg') !== -1 || img.search('http://') !== -1 || img.search('https://') !== -1) {
+    return img;
+  } else if (img.search(url) === -1) { // 이미지가 뜨지 않을 때
+    return `${url}/${img}`  
+  } 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 기능 수정 :
- [x] 버그 수정 : follow 이미지 엑박 처리, css 수정
- [ ] 기타 : 

### 변경사항 및 이유

- 하나의 서버를 여러 프로젝트에서 사용하기에 처리과정이 이미지가 보여지지
않는 현상 발생

### 작업 내역

- 예외처리로 해당 이미지가 보이도록 한다. 감귤마켓의 기본 이미지도
홀로그램의 기본이미지로 보이게한다.

### 작업 후 기대 동작(스크린샷)

![image](https://user-images.githubusercontent.com/76831344/181292562-308fa668-9c4c-4b50-92be-6703f6c91661.png)

- 이전 이미지
![image](https://user-images.githubusercontent.com/76831344/181292617-c8be1f19-0e52-42f7-b89b-7241c770612a.png)

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #310

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
모든 페이지에 동일하게 함수를 사용하려고 하는데 
함수는 common.js에 두고
marketImg, mandarinImg, defaultImg은 프로필과 게시글 따로 지정하는게 좋을까요?
현재는 해당 변수들이 프로필을 기준으로 값이 정해져있어요.

<!-- 좋은 pr 체크리스트 -->

<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항
-->
